### PR TITLE
Regularize following Lyapunov functions

### DIFF
--- a/src/lqr.ml
+++ b/src/lqr.ml
@@ -27,7 +27,6 @@ let backward flxx flx tape =
         :: tl ->
         let at = AD.Maths.transpose a in
         let bt = AD.Maths.transpose b in
-        let n = AD.Mat.row_num a in
         let m = AD.Mat.row_num b in
         let qx = AD.Maths.(rlx + (vx *@ at)) in
         let qu = AD.Maths.(rlu + (vx *@ bt)) in

--- a/src/regularisation.ml
+++ b/src/regularisation.ml
@@ -1,3 +1,6 @@
+open Owl
+module AD = Algodiff.D
+
 type t = float * float
 
 let increase (delta, mu) =
@@ -16,7 +19,8 @@ let decrease (delta, mu) =
 
 let regularize mat =
   let n = AD.Mat.row_num mat in
-  let w = AD.Mat.min_eig mat in
-  if w < 1e-8
-  then mat +. AD.abs w * Ad.Mat.eye n
+  let _, svs, _ = Linalg.D.svd (AD.unpack_arr mat) in
+  let w_min = Mat.min' svs in
+  if w_min < 1e-8
+  then AD.Maths.(mat - AD.F w_min * AD.Mat.eye n)
   else mat

--- a/src/regularisation.ml
+++ b/src/regularisation.ml
@@ -13,3 +13,10 @@ let decrease (delta, mu) =
     if mu > 1E-6 then mu else 0.
   in
   delta, mu
+
+let regularize mat =
+  let n = AD.Mat.row_num mat in
+  let w = AD.Mat.min_eig mat in
+  if w < 1e-8
+  then mat +. AD.abs w * Ad.Mat.eye n
+  else mat


### PR DESCRIPTION
Cost matrices rlxx and rluu are now made to be positive definite, instead of correcting quu